### PR TITLE
WIP: Main app architecture with basic functionality

### DIFF
--- a/scripts/aiohabit
+++ b/scripts/aiohabit
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 # Copyright 2020 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,19 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module to work with provisioning config.
+from aiohabit import run
 
-Provisioning config is general project configuration shared between multiple jobs
-"""
-
-
-class ProvisioningConfig:
-    """Represents loaded provisioning configuration."""
-
-    def __init__(self, data):
-        """Initialize provisioning configuration."""
-        self.raw = data
-
-    def raw(self):
-        """Get raw configuration."""
-        return self._raw()
+if __name__ == "__main__":
+    run.run()

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     install_requires=["asyncopenstackclient"],
+    scripts=["scripts/aiohabit"],
 )

--- a/src/aiohabit/actions/__init__.py
+++ b/src/aiohabit/actions/__init__.py
@@ -12,19 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module to work with provisioning config.
 
-Provisioning config is general project configuration shared between multiple jobs
-"""
-
-
-class ProvisioningConfig:
-    """Represents loaded provisioning configuration."""
-
-    def __init__(self, data):
-        """Initialize provisioning configuration."""
-        self.raw = data
-
-    def raw(self):
-        """Get raw configuration."""
-        return self._raw()
+"""aiohabit actions."""

--- a/src/aiohabit/actions/destroy.py
+++ b/src/aiohabit/actions/destroy.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Destroy action module."""
+
+import asyncio
+from ..host import STATUS_DELETED
+
+
+class Destroy:
+    """Destroy action.
+
+    Destroy all still active provisioned host. Save the state to DB.
+    """
+
+    def __init__(self, config, metadata, db_driver):
+        """Initialize the destroy action."""
+        self._config = config
+        self._metadata = metadata
+        self._db_driver = db_driver
+
+    async def destroy(self):
+        """Execute the destroy action."""
+        hosts = self._db_driver.hosts
+        results_aws = []
+        for host in hosts.values():
+            if host.status == STATUS_DELETED:
+                continue
+            aw = host.delete()
+            results_aws.append(aw)
+        delete_results = await asyncio.gather(*results_aws)
+        success = all(delete_results)
+        self._db_driver.update_hosts(hosts)
+        return success

--- a/src/aiohabit/actions/up.py
+++ b/src/aiohabit/actions/up.py
@@ -1,0 +1,96 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Up action module."""
+
+import asyncio
+from ..errors import MetadataError
+from ..utils import validate_dict_attrs
+from ..transformers import transformers
+from ..providers import providers
+
+
+class Up:
+    """
+    Up action.
+
+    UP action provision all hosts defined in domain object of provided job
+    metadata.
+
+    The provisioning information is created by transformers from metadata
+    and provisioning configuration (config).
+
+    Results of provisioning is saved by 'db_driver'.
+
+    Output objects generate the resulting output artifacts, e.g. Ansible
+    inventory.
+    """
+
+    def __init__(self, config, metadata, default_provider, db_driver):
+        """Initialize the Up action."""
+        self._transformers = {}
+        self._config = config
+        self._metadata = metadata
+        self._db_driver = db_driver
+
+        self.validate_topology()
+        default_provider_name = self._config.get("provider", default_provider)
+        default_provider_name = self._metadata.get("provider", default_provider_name)
+        for domain in self._metadata["domains"]:
+            for host in domain["hosts"]:
+                provider_name = host.get("provider", default_provider_name)
+                transformer = transformers.get(provider_name)
+                transformer.validate_host(host)
+                transformer.add_host(host)
+
+    def _get_transformer(self, provider_name):
+        """Get a transformer by name, initialize a new one if not yet done."""
+        transformer = self._transformers.get(provider_name)
+        if not transformer:
+            transformer = transformers.get(provider_name)
+            if not transformer:
+                raise MetadataError(f"Invalid provider: {provider_name}")
+            self._transformers[provider_name] = transformer
+        return transformer
+
+    def validate_topology(self):
+        """Validate topology part of job metadata.
+
+        Raises: MetadataError
+        """
+        if "domains" not in self._metadata:
+            error = (
+                "Error: job metadata file doesn't contain required "
+                "`domains` definition"
+            )
+            raise MetadataError(error)
+        for domain in self._metadata["domains"]:
+            validate_dict_attrs(domain, self._required_domain_attrs, "domain")
+
+    async def provision(self):
+        """Execute the up action."""
+        prov_aws = []
+        for provider_name, transformer in self._transformers.items():
+            reqs = transformer.create_host_requirements()
+            provider = providers.get(provider_name)
+            aws = provider.provision_hosts(reqs)
+            prov_aws.append(aws)
+        provisioning_results = await asyncio.gather(*prov_aws)
+
+        hosts = []
+        for results in provisioning_results:
+            hosts.extend(results)
+
+        self._db_driver.add_hosts(hosts)
+        return hosts

--- a/src/aiohabit/dbdrivers/__init__.py
+++ b/src/aiohabit/dbdrivers/__init__.py
@@ -12,19 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module to work with provisioning config.
 
-Provisioning config is general project configuration shared between multiple jobs
+"""aiohabit database drivers.
+
+A database driver persists and loads results of actions so that it can be used in
+consecutive actions.
 """
-
-
-class ProvisioningConfig:
-    """Represents loaded provisioning configuration."""
-
-    def __init__(self, data):
-        """Initialize provisioning configuration."""
-        self.raw = data
-
-    def raw(self):
-        """Get raw configuration."""
-        return self._raw()

--- a/src/aiohabit/dbdrivers/file.py
+++ b/src/aiohabit/dbdrivers/file.py
@@ -1,0 +1,87 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File database driver module."""
+
+from os import path
+from ..host import host_from_json
+from ..utils import save_to_json, load_json
+
+HOSTS_KEY = "hosts"
+
+
+class FileDBDriver:
+    """File database driver.
+
+    Serialize and load information into JSON file.
+    """
+
+    def __init__(self, path):
+        """Initialize DB driver."""
+        self._path = path
+        self._hosts = {}
+        self._raw_data = None
+        self.save_on_change = True
+        self.load(path)
+
+    def load(self):
+        """Load configuration from file."""
+        self._hosts = {}
+        if not path.exists(self._path):
+            self._raw_data = {HOSTS_KEY: {}}
+            return self._hosts
+
+        self._raw_data = load_json(self._path)
+        raw_hosts = self._raw_data.get(HOSTS_KEY, [])
+
+        self._hosts = {}
+        for raw_host in raw_hosts:
+            host = host_from_json(raw_host)
+            self._hosts[host.name] = host
+
+        return self._hosts
+
+    def save(self):
+        """Save configuration to file."""
+        hosts = [host.to_json() for host in self._hosts.values()]
+        self._raw_data[HOSTS_KEY] = hosts
+        save_to_json(self._path, self._raw_data)
+
+    @property
+    def hosts(self):
+        """Get all host objects loaded or to be saved."""
+        return self._hosts
+
+    def add_hosts(self, hosts):
+        """Add a host object.
+
+        Save it to file automatically if `save_on_change` is set to True.
+        """
+        for host in hosts:
+            self.hosts[host.name] = host
+
+        if self.save_on_change:
+            self.save()
+
+    def update_hosts(self, hosts):
+        """Update managed host objects.
+
+        Only adds.
+        """
+        self.add_hosts(hosts)
+
+    def delete_host(self, host):
+        """Delete host object."""
+        if host.name in self.hosts:
+            del self.hosts[host.name]

--- a/src/aiohabit/errors.py
+++ b/src/aiohabit/errors.py
@@ -21,8 +21,22 @@ class ConfigError(Exception):
     pass
 
 
+class MetadataError(Exception):
+    """Error in job metadata."""
+
+    pass
+
+
+class ProviderNotExists(ConfigError):
+    """Request provider does not exist."""
+
+    def __init__(self, name):
+        """Init the error with provider name."""
+        self._provider_name = name
+
+
 class ProvisioningConfigError(ConfigError):
-    """Error in provisioning configuraiton."""
+    """Error in provisioning configuration."""
 
     pass
 

--- a/src/aiohabit/host.py
+++ b/src/aiohabit/host.py
@@ -1,0 +1,122 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host object."""
+
+from .utils import print_obj
+from .providers import providers
+
+STATUS_PENDING = "pending"
+STATUS_PROVISIONING = "provisioning"
+STATUS_ACTIVE = "active"
+STATUS_ERROR = "error"
+STATUS_DELETED = "deleted"
+STATUS_DELETING = "deleting"
+STATUS_OTHER = "other"
+
+STATUSES = [
+    STATUS_PENDING,
+    STATUS_PROVISIONING,
+    STATUS_ACTIVE,
+    STATUS_ERROR,
+    STATUS_DELETED,
+    STATUS_DELETING,
+]
+
+
+def host_from_json(host_data):
+    """Reverse method to Host.__json__() after json.loads()."""
+    provider_name = host_data["provider"]
+    provider = providers.get(provider_name)
+    host = Host(
+        provider,
+        host_data["id"],
+        host_data["name"],
+        host_data["ips"],
+        host_data["status"],
+        host_data["rawdata"],
+        host_data["username"],
+        host_data["password"],
+        host_data["error"],
+    )
+    return host
+
+
+class Host:
+    """Provisioned host.
+
+    Normalized values from providers to offer consistent interface.
+    """
+
+    def __init__(
+        self,
+        provider,
+        id,
+        name,
+        ips,
+        status,
+        rawdata,
+        username=None,
+        password=None,
+        error_obj=None,
+    ):
+        """Initialize host object."""
+        self._provider = provider
+        self._id = id
+        self._name = name
+        self._ips = ips
+        self._status = status
+        self._username = username
+        self._password = password
+        self._rawdata = rawdata
+        self._error = error_obj
+
+    def __str__(self):
+        """Return string representation of host."""
+        net_str = " ".join(self._ips)
+
+        print(f"{self._id} {self._name} {net_str} {self.username} " f"{self.password}")
+        if self.error_obj:
+            print("Error:")
+            print_obj(self.error_obj)
+
+    def to_json(self):
+        """Transform object into representation which is acceptable by `json.dump`."""
+        return {
+            "provider": self._provider.name,
+            "id": self._id,
+            "name": self._name,
+            "ips": self._ips,
+            "status": self._status,
+            "username": self._username,
+            "password": self._password,
+            "rawdata": self._rawdata,
+            "error": self._error,
+        }
+
+    @property
+    def name(self):
+        """Get host name."""
+        return self._name
+
+    @property
+    def status(self):
+        """Get host status."""
+        return self._status
+
+    async def delete(self):
+        """Issue host deletion via associated provider."""
+        await self.provider.delete_host(self)
+        self._status = STATUS_DELETED
+        return True

--- a/src/aiohabit/outputs/__init__.py
+++ b/src/aiohabit/outputs/__init__.py
@@ -12,19 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module to work with provisioning config.
+"""Outputs package.
 
-Provisioning config is general project configuration shared between multiple jobs
+Outputs generate various output artifacts from provisioning results.
 """
-
-
-class ProvisioningConfig:
-    """Represents loaded provisioning configuration."""
-
-    def __init__(self, data):
-        """Initialize provisioning configuration."""
-        self.raw = data
-
-    def raw(self):
-        """Get raw configuration."""
-        return self._raw()

--- a/src/aiohabit/providers/__init__.py
+++ b/src/aiohabit/providers/__init__.py
@@ -1,1 +1,58 @@
-"""Provisioning providers."""
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provisioning providers.
+
+Providers provisions resources in Clouds or other means based on provisioning
+requirements (e.g. host requirements)
+"""
+
+from ..errors import ProviderNotExists
+
+
+class Registry:
+    """Provider registry."""
+
+    def __init__(self):
+        """Initialize Registry."""
+        self._provider_cls = dict()
+        self._providers = dict()
+
+    def register(self, name, provider_cls):
+        """Register new provider."""
+        self._provider_cls[name] = provider_cls
+
+    def get(self, name):
+        """Get a provider object by name.
+
+        Instantiate the provider if not done yet.
+
+        Raises: ProviderNotExists
+        """
+        prov_cls = self._provider_cls.get(name)
+        if not prov_cls:
+            raise ProviderNotExists(name)
+        provider = self._providers.get(name)
+        if not provider:
+            provider = prov_cls()
+            self._providers[name] = provider
+        return provider
+
+    @property
+    def names(self):
+        """Get all registered provider names."""
+        return self._provider_cls.keys()
+
+
+providers = Registry()

--- a/src/aiohabit/providers/provider.py
+++ b/src/aiohabit/providers/provider.py
@@ -20,9 +20,15 @@ class Provider:
 
     def __init__(self, provisioning_config, job_config):
         """Initialize provider."""
+        self._name = "dummy"
         return
 
-    async def validate_hosts(hosts):
+    @property
+    def name(self):
+        """Get provider name."""
+        return self._name
+
+    async def validate_hosts(self, hosts):
         """Validate that host requirements are well specified."""
         return
 

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -1,0 +1,100 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""aiohabit default app."""
+
+import asyncio
+import click
+
+from .dbdrivers.file import FileDBDriver
+from .utils import load_json, print_obj
+from .config import ProvisioningConfig
+from .actions.destroy import Destroy
+from .actions.up import Up
+from .providers import providers
+from .providers.openstack import OpenStackProvider, KEY as OPENSTACK_KEY
+
+
+def init_providers():
+    """Register all providers usable in this session."""
+    providers.register(OPENSTACK_KEY, OpenStackProvider)
+
+
+def init_db(path):
+    """Initialize file database."""
+    db = FileDBDriver(path)
+    return db
+
+
+def init_config(path):
+    """Load and initialize provisioning configuration."""
+    config_data = load_json(path)
+    config = ProvisioningConfig(config_data)
+    return config
+
+
+def init_metadata(path):
+    """Load and initialize job metadata."""
+    metadata_data = load_json(path)
+    return metadata_data
+
+
+DB = "db"
+CONFIG = "config"
+META = "metadata"
+
+
+@click.group()
+@click.option("-c", "--config", default="./provisioning-config.yaml")
+@click.option("-d", "--db", default="./.aiohabitdb.json")
+@click.pass_context
+def aiohabitcli(ctx, config, db):
+    """Multihost human friendly provisioner."""
+    init_providers()
+    ctx.ensure_object(dict)
+    ctx[DB] = init_db(db)
+    ctx[CONFIG] = init_config(config)
+
+
+@aiohabitcli.command()
+@click.pass_context
+@click.argument("metadata")
+@click.option("-p", "--provider", default="openstack")
+async def up(ctx, metadata, provider):
+    """Provision hosts.
+
+    Based on provided job metadata file and provisioning configuration.
+    """
+    ctx[META] = init_metadata(metadata)
+    up_action = Up(ctx[CONFIG], ctx[META], provider, ctx[DB])
+    hosts = await up_action.provision()
+    print_obj(hosts)
+
+
+@aiohabitcli.command()
+@click.pass_context
+async def destroy(ctx):
+    """Destroy provisioned hosts."""
+    destroy_action = Destroy(ctx[CONFIG], ctx[DB])
+    result = await destroy_action.destroy()
+    print_obj(result)
+
+
+def run():
+    """Run the app."""
+    asyncio.run(aiohabitcli(obj={}))
+
+
+if __name__ == "__main__":
+    run()

--- a/src/aiohabit/transformers/__init__.py
+++ b/src/aiohabit/transformers/__init__.py
@@ -1,0 +1,58 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provisioning transformers.
+
+Transformers take job definitions, combine it with provisioning configuration
+and returns provisioning requirements (input for provisioners).
+"""
+
+from ..errors import ProviderNotExists
+from .openstack import OpenStackTransformer, CONFIG_KEY as OPENSTACK_KEY
+
+
+class Registry:
+    """Transformers registry."""
+
+    def __init__(self):
+        """Initialize transformer registry."""
+        self._transformer_cls = dict()
+        self._transformers = dict()
+
+    def register(self, name, transformer_cls):
+        """Register new tranformer class."""
+        self._transformer_cls[name] = transformer_cls
+
+    def get(self, name):
+        """Get Transformer instance by name.
+
+        Initialize the the transformer if not done yet.
+        """
+        trans_cls = self._transformer_cls.get(name)
+        if not trans_cls:
+            raise ProviderNotExists(name)
+        transformer = self._transformers.get(name)
+        if not transformer:
+            transformer = trans_cls()
+            self._transformers[name] = transformer
+        return transformer
+
+    @property
+    def names(self):
+        """Get all registered transformer names."""
+        return self._transformer_cls.keys()
+
+
+transformers = Registry()
+transformers.register(OPENSTACK_KEY, OpenStackTransformer)

--- a/src/aiohabit/transformers/openstack.py
+++ b/src/aiohabit/transformers/openstack.py
@@ -1,0 +1,168 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenStack transformer module."""
+
+from .transformer import Transformer
+from ..utils import get_config_value
+from ..errors import ProvisioningConfigError
+
+CONFIG_KEY = "openstack"
+
+
+class OpenStackTransformer(Transformer):
+    """OpenStack transformer."""
+
+    _config_key = CONFIG_KEY
+    _required_config_attrs = [
+        "flavors",
+        "networks",
+        "images",
+        "keypair",
+        "profile",
+        "credentials_file",
+    ]
+
+    def __init__(self, cfg, metadata):
+        """Initialize OpenStack transformer."""
+        super().__init__(cfg, metadata)
+
+    def _get_flavor(self, host):
+        """Get flavor by host group."""
+        # TODO: add sizes
+
+        return get_config_value(self.config["flavors"], host["group"])
+
+    def _is_network_type(self, name):
+        """Check if name is a configured network type in provisioning config."""
+        nt = self.config["networks"].get(name)
+        return bool(nt)
+
+    def _aggregate_networks(self, hosts):
+        """
+        Get how many host require each used network type.
+
+        Returns: dict where keys are network types and values are total count.
+        """
+        nts = {}
+        for host in hosts:
+            # skip hosts which have low-level network names defined
+            # this can be extended to pick network type based on the network name
+            names = host.get("networks")
+            if names:
+                continue
+            nt = host.get("network")
+            if not self._is_network_type(nt):
+                continue
+
+            count = nts.get(nt, 0)
+            count += 1
+            nts[nt] = count
+        return nts
+
+    def _pick_network(self, network_type, count):
+        """
+        Pick network based network type and needed amount.
+
+        Usable network with most IPs available is picked.
+        """
+        possible_networks = self.config["networks"][network_type]
+        networks = [self._provider.get_network(net) for net in possible_networks]
+        usable = []
+        for network in networks:
+            ips = self._provider.get_ips(ref=network.get("id"))
+            available = ips["total_ips"] - ips["used_ips"]
+            if available > count:
+                usable.append((network["name"], available))
+
+        if not usable:
+            print("Error: no usable network for {count} hosts with {network_type}")
+            return None
+
+        # sort networks by number of available IPs
+        usable = sorted(usable, key=lambda u: u[1])
+        print(usable)
+        return usable[-1][0]  # Pick the one with most IPs
+
+    def translate_network_types(self, hosts):
+        """Pick the right OpenStack networks for all hosts.
+
+        Pick the network based on network type, networks configured for the
+        type and the available IP addresses. Process all hosts to
+        be able to pick the network which have enough addresses for all hosts.
+
+        All hosts will have either "networks" attribute or "network"
+        host attribute set with OpenStack network name or ID.
+        """
+        nt_requirements = self._aggregate_networks(hosts)
+        nt_map = {}
+        for network_type, count in nt_requirements.items():
+            network_name = self._pick_network(network_type, count)
+            nt_map[network_type] = network_name
+
+        for host in hosts:
+            # skip hosts which have low-level network names defined
+            names = host.get("networks")
+            if names:
+                continue
+
+            nt = host.get("network")
+
+            if not self.is_network_type(nt):
+                continue
+
+            network_name = nt_map[nt]
+            host["network"] = network_name
+
+    def _get_network_type(self, host):
+        """Get network type from host object definition.
+
+        If host object doesn't have it defined, then get it from metadata or
+        provisioning config.
+        """
+        network_type = host.get("network")
+        default_network = self.config.get("default_network")
+        if network_type is None:
+            network_type = self._metadata.get("network", default_network)
+        if not network_type:
+            raise ProvisioningConfigError(
+                "No network type specified and project doesn't have default "
+                "network type (property 'default_network') specified in "
+                "provisioning config."
+            )
+        return network_type
+
+    def _get_image(self, os):
+        """Get image name by OS name from provisioning config."""
+        return get_config_value(self.config["images"], os)
+
+    def create_host_requirement(self, host):
+        """Create single input for OpenStack provisioner."""
+        return {
+            "name": host["name"],
+            "flavor": self._get_flavor(host["group"]),
+            "image": self._get_image(host["os"]),
+            "key_name": self.config["keypair"],
+            "network": self._get_network_type(host),
+        }
+
+    def create_host_requirements(self):
+        """Create inputs for all host for OpenStack provisioner.
+
+        This includes picking the right network and checking if it has
+        available IP addresses.
+        """
+        reqs = [self.create_host_requirement(host) for host in self.hosts]
+        self.translate_network_types(reqs)
+        return reqs

--- a/src/aiohabit/transformers/transformer.py
+++ b/src/aiohabit/transformers/transformer.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic Transformer."""
+
+from ..errors import ConfigError, MetadataError
+from ..utils import validate_dict_attrs
+from ..providers import providers
+
+
+class Transformer:
+    """Base class for transformers."""
+
+    _required_host_attrs = ["name", "os", "group"]
+    _required_config_attrs = []
+    _config_key = None
+
+    def __init__(self, cfg, metadata):
+        """Initialize transformer."""
+        self._hosts = []
+        self._config = cfg
+        self._metadata = metadata
+        self._provider = providers.get(self._config_key)
+        if self._config_key:
+            self.validate_config()
+
+    @property
+    def config(self):
+        """Get transformer/provider configuration from provisioning configuration."""
+        key = self._config_key
+        try:
+            return self._config[key]
+        except KeyError:
+            error = f"No '{key}' entry in provisioning configuration"
+            raise ConfigError(error)
+
+    @property
+    def hosts(self):
+        """Get all host inputs this transformer is handling."""
+        return self._hosts
+
+    def add_host(self, host):
+        """Add host input."""
+        self._hosts.append(host)
+
+    def validate_config(self):
+        """Validate provisioning configuration for this transformer/provider."""
+        validate_dict_attrs(self.config, self._required_config_attrs, "config")
+
+    def validate_host(self, host):
+        """Validate host input that it contains everything needed by provider."""
+        # attribute check
+        validate_dict_attrs(host, self._required_host_attrs, "host")
+        # provider check
+        provider = host.get("provider")
+        if provider and provider not in providers.names:
+            raise MetadataError(f"Error: Invalid host provider: {provider}")

--- a/src/aiohabit/utils.py
+++ b/src/aiohabit/utils.py
@@ -18,6 +18,7 @@
 import base64
 import datetime
 import json
+import sys
 
 from .errors import ConfigError
 
@@ -39,7 +40,7 @@ def get_config_value(config_dict, key, default=None):
 
 
 def validate_dict_attrs(dct, attr_list, dct_name):
-    """Validate that dictionary contains all atributes.
+    """Validate that dictionary contains all attributes.
 
     Based on provided attribute list.
     """
@@ -68,6 +69,23 @@ def json_convertor(obj):
 
     if "Decimal" in str(obj.__class__):
         return str(obj)
+
+
+def load_json(path):
+    """Load JSON file into Python object."""
+    with open(path, "r") as file_data:
+        data = json.load(file_data)
+    return data
+
+
+def save_to_json(path, data):
+    """Serialize object into JSON file."""
+    try:
+        with open(path, "w") as output:
+            json.dump(data, output, default=json_convertor, indent=2, sort_keys=True)
+    except IOError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        exit(1)
 
 
 def print_obj(obj):


### PR DESCRIPTION
Adding:
- up action
- destroy action

Introducing concepts:

Trasnsformers: combines metadata together with provisioning config to
get configuration for providers.

Outputs: transform result of providers to various files like ansible
inventory or pytest-multihost config

Drivers: saves results of actions to file so that it can be used
later. E.g. up action result to be used for destroy action.

Adds basic CLI entry point for debugging or standalone usage.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>