### PR TITLE
Minor fixes to the sources and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+click
+pyyaml
 asyncopenstackclient

--- a/src/aiohabit/dbdrivers/file.py
+++ b/src/aiohabit/dbdrivers/file.py
@@ -33,7 +33,7 @@ class FileDBDriver:
         self._hosts = {}
         self._raw_data = None
         self.save_on_change = True
-        self.load(path)
+        self.load()
 
     def load(self):
         """Load configuration from file."""

--- a/src/aiohabit/providers/openstack.py
+++ b/src/aiohabit/providers/openstack.py
@@ -92,7 +92,7 @@ class OpenStackProvider(Provider):
 
         login_start = datetime.now()
         await asyncio.gather(
-            self.nova.init_api(), self.glance.init_api(), self.neutron.init_api(),
+            self.nova.init_api(), self.glance.init_api(), self.neutron.init_api()
         )
         login_end = datetime.now()
         login_duration = login_end - login_start

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -18,7 +18,7 @@ import asyncio
 import click
 
 from .dbdrivers.file import FileDBDriver
-from .utils import load_json, print_obj
+from .utils import load_yaml, print_obj
 from .config import ProvisioningConfig
 from .actions.destroy import Destroy
 from .actions.up import Up
@@ -39,14 +39,14 @@ def init_db(path):
 
 def init_config(path):
     """Load and initialize provisioning configuration."""
-    config_data = load_json(path)
+    config_data = load_yaml(path)
     config = ProvisioningConfig(config_data)
     return config
 
 
 def init_metadata(path):
     """Load and initialize job metadata."""
-    metadata_data = load_json(path)
+    metadata_data = load_yaml(path)
     return metadata_data
 
 
@@ -63,8 +63,8 @@ def aiohabitcli(ctx, config, db):
     """Multihost human friendly provisioner."""
     init_providers()
     ctx.ensure_object(dict)
-    ctx[DB] = init_db(db)
-    ctx[CONFIG] = init_config(config)
+    ctx.obj[DB] = init_db(db)
+    ctx.obj[CONFIG] = init_config(config)
 
 
 @aiohabitcli.command()

--- a/src/aiohabit/utils.py
+++ b/src/aiohabit/utils.py
@@ -18,7 +18,10 @@
 import base64
 import datetime
 import json
+import yaml
 import sys
+import contextlib
+
 
 from .errors import ConfigError
 
@@ -78,6 +81,13 @@ def load_json(path):
     return data
 
 
+def load_yaml(path):
+    """Load YAML file into Python object."""
+    with open(path, "r") as file_data:
+        data = yaml.safe_load(file_data)
+    return data
+
+
 def save_to_json(path, data):
     """Serialize object into JSON file."""
     try:
@@ -86,6 +96,31 @@ def save_to_json(path, data):
     except IOError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         exit(1)
+
+
+@contextlib.contextmanager
+def fd_open(filename=None):
+    """Use file or stout as output file descriptor."""
+    if filename:
+        fd = open(filename, "w")
+    else:
+        fd = sys.stdout
+
+    try:
+        yield fd
+    finally:
+        if fd is not sys.stdout:
+            fd.close()
+
+
+def save_yaml(path, yaml_data):
+    """
+    Write yaml data with file.write(yaml.dump()) to file specified by path.
+
+    If path is not specified use stdout.
+    """
+    with fd_open(path) as yaml_file:
+        yaml_file.write(yaml.dump(yaml_data, default_flow_style=False))
 
 
 def print_obj(obj):


### PR DESCRIPTION
Fixing:
db_driver.load() to take no params as the path is handled in init
ctx object should have ctx.obj to be accessed with key
Adding:
requirements were missing when installing in clear environment
yaml lib helper functions