### PR TITLE
Ansible Inventory and pytest-multihost output modules

### DIFF
--- a/src/aiohabit/actions/output.py
+++ b/src/aiohabit/actions/output.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Output action."""
+
+from aiohabit.outputs.ansible_inventory import AnsibleInventoryOutput
+from aiohabit.outputs.pytest_multihost import PytestMultihostOutput
+
+
+class Output:
+    """
+    Output action.
+
+    Test action to run output modules from data in database.
+    """
+
+    async def init(self, config, metadata, db_driver):
+        """Initialize the Output action."""
+        self._config = config
+        self._metadata = metadata
+        self._db_driver = db_driver
+
+    async def generate_outputs(self):
+        """Generate outputs."""
+        ansible_o = AnsibleInventoryOutput(
+            self._config, self._db_driver, self._metadata
+        )
+        multihost_o = PytestMultihostOutput(
+            self._config, self._db_driver, self._metadata
+        )
+
+        ansible_o.create_output()
+        multihost_o.create_output()
+
+        print("Output generation done")
+        return True

--- a/src/aiohabit/host.py
+++ b/src/aiohabit/host.py
@@ -108,19 +108,39 @@ class Host:
         }
 
     @property
-    def name(self):
-        """Get host name."""
-        return self._name
-
-    @property
     def provider(self):
         """Get host provisioning provider."""
         return self._provider
 
     @property
+    def id(self):
+        """Get provider host id."""
+        return self._id
+
+    @property
+    def name(self):
+        """Get host name."""
+        return self._name
+
+    @property
+    def ips(self):
+        """Get host IP addresses."""
+        return self._ips
+
+    @property
     def status(self):
         """Get host status."""
         return self._status
+
+    @property
+    def username(self):
+        """Get username for connecting to host."""
+        return self._username
+
+    @property
+    def password(self):
+        """Get password for connecting to host."""
+        return self._password
 
     async def delete(self):
         """Issue host deletion via associated provider."""

--- a/src/aiohabit/outputs/ansible_inventory.py
+++ b/src/aiohabit/outputs/ansible_inventory.py
@@ -1,0 +1,143 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ansible inventory output module."""
+
+from copy import deepcopy
+from aiohabit.outputs.utils import is_windows_host, resolve_hostname
+from aiohabit.utils import get_config_value, get_host_from_metadata, save_yaml
+
+DEFAULT_INVENTORY_PATH = "aiohabit-inventory.yaml"
+DEFAULT_INVENTORY_LAYOUT = {"all": {"children": {}, "hosts": {}}}
+
+
+def copy_meta_attrs(host, meta_host, attrs):
+    """Copy attributes from host metadata entry and prefixing them with meta."""
+    for attr in attrs:
+        val = meta_host.get(attr)
+        if val:
+            host[f"meta_{attr}"] = val
+
+
+def find_group(inventory, group_names, top=True):
+    """Find first matching group in inventory which has one of the provided names."""
+    if not inventory:
+        return None
+
+    groups = inventory.keys()
+    for group in groups:
+        if group in group_names:
+            return inventory[group]
+
+    for group in groups:
+        g = inventory[group]
+
+        if "children" not in g:
+            continue
+
+        found = find_group(g["children"], group_names, top=False)
+        if found:
+            return found
+
+    if top:
+        return inventory["all"]
+
+    return None
+
+
+class AnsibleInventoryOutput:
+    """
+    Generate Ansible inventory with provisioned machines.
+
+    The resulting inventory combines data from provisioning config, job metadata
+    files and information in DB.
+    """
+
+    def __init__(self, config, db, metadata, path=DEFAULT_INVENTORY_PATH):
+        """Init the output module."""
+        self._config = config
+        self._db = db
+        self._metadata = metadata
+        self._path = path
+
+    def create_ansible_host(self, name):
+        """Create host entry for Ansible inventory."""
+        meta_host, meta_domain = get_host_from_metadata(self._metadata, name)
+        db_host = self._db.hosts[name]
+
+        ip = db_host.ips[0]
+        ansible_host = resolve_hostname(ip) or ip
+
+        python = (
+            self._config["python"][meta_host["os"]] or self._config["python"]["default"]
+        )
+
+        default_user = get_config_value(self._config["users"], meta_host["os"])
+        ansible_user = db_host.username or meta_host.get("username", default_user)
+
+        # Common attributes
+        host_info = {
+            "ansible_host": ansible_host,
+            "ansible_python_interpreter": python,
+            "ansible_user": ansible_user,
+            "meta_fqdn": name,
+            "meta_domain": meta_domain["name"],
+            "meta_provider_id": db_host.id,
+            "meta_ip": ip,
+            "meta_dc_record": ",".join(
+                "DC=%s" % dc for dc in meta_domain["name"].split(".")
+            ),
+        }
+        copy_meta_attrs(host_info, meta_host, ["os", "role", "netbios"])
+
+        if "parent" in meta_domain:
+            host_info["parent_domain"] = meta_domain["parent"]
+
+        if is_windows_host(meta_host):
+            password = meta_host.get(
+                "password", self._config["mhcfg"]["ad_admin_password"]
+            )
+            host_info.update(
+                {
+                    "ansible_password": password,
+                    "ansible_port": 5986,
+                    "ansible_connection": "winrm",
+                    "ansible_winrm_server_cert_validation": "ignore",
+                    "meta_domain_level": meta_host.get("domain_level", "top"),
+                }
+            )
+        return host_info
+
+    def create_inventory(self):
+        """Create the Ansible inventory in dict form."""
+        provisioned = self._db.hosts
+        inventory = deepcopy(
+            self._config.get("inventory_layout", DEFAULT_INVENTORY_LAYOUT)
+        )
+
+        for host in provisioned.values():
+            meta_host, meta_domain = get_host_from_metadata(self._metadata, host.name)
+            groups = meta_host.get("groups") or [meta_host.get("group", "all")]
+            group = find_group(inventory, groups)
+            if "hosts" not in group:
+                group["hosts"] = {}
+
+            group["hosts"][host.name] = self.create_ansible_host(host.name)
+        return inventory
+
+    def create_output(self):
+        """Create the target output file."""
+        inventory = self.create_inventory()
+        save_yaml(self._path, inventory)
+        return inventory

--- a/src/aiohabit/outputs/utils.py
+++ b/src/aiohabit/outputs/utils.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for output modules."""
+
+import socket
+from socket import error as socket_error
+
+
+def resolve_hostname(ip):
+    """Resolve IP address to hostname."""
+    try:
+        return socket.gethostbyaddr(ip)[0]
+    except socket_error:
+        return None
+
+
+def is_windows_host(meta_host):
+    """
+    Return if host is Windows host based on host metadata info.
+
+    Host is windows host if:
+    * os starts with 'win' or
+    * os_type is 'windows'
+    """
+    return (
+        meta_host.get("os", "").startswith("win")
+        or meta_host.get("os_type", "") == "windows"
+    )

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -24,6 +24,7 @@ from aiohabit.utils import load_yaml, no_such_file_config_handler
 from aiohabit.config import ProvisioningConfig
 from aiohabit.actions.destroy import Destroy
 from aiohabit.actions.up import Up
+from aiohabit.actions.output import Output
 from aiohabit.providers import providers
 from aiohabit.providers.openstack import OpenStackProvider, PROVISIONER_KEY as OPENSTACK
 from aiohabit.providers.aws import AWSProvider, PROVISIONER_KEY as AWS
@@ -100,6 +101,10 @@ async def up(ctx, metadata, provider):
     await up_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], provider, ctx.obj[DB])
     await up_action.provision()
 
+    output_action = Output()
+    await output_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await output_action.generate_outputs()
+
 
 @aiohabitcli.command()
 @click.pass_context
@@ -111,6 +116,18 @@ async def destroy(ctx, metadata):
     destroy_action = Destroy()
     await destroy_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await destroy_action.destroy()
+
+
+@aiohabitcli.command()
+@click.pass_context
+@click.argument("metadata")
+@async_run
+async def output(ctx, metadata):
+    """Create outputs - such as Ansible inventory."""
+    ctx.obj[METADATA] = init_metadata(metadata)
+    output_action = Output()
+    await output_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    await output_action.generate_outputs()
 
 
 def exception_handler(func):

--- a/src/aiohabit/utils.py
+++ b/src/aiohabit/utils.py
@@ -133,6 +133,20 @@ def print_obj(obj):
     print(object2json(obj))
 
 
+def get_host_from_metadata(metadata, name):
+    """
+    Get host definition from job metadata base on name.
+
+    Returns:
+    (host, domain)
+    """
+    domains = metadata.get("domains", [])
+    for domain in domains:
+        for host in domain.get("hosts", []):
+            if host["name"] == name:
+                return host, domain
+
+
 class no_such_file_config_handler(object):
     """
     Decorator which change error into ConfigError with custom message.


### PR DESCRIPTION
## Add Ansible Inventory and pytest-multihost output modules

And enhance "up" action to use them. Add also "output" action which  calls them separately. It can be used for recreation of deleted ones  or testing.
    
## hosts: adding missing properties
    
So that they can be work with in output modules.
