### PR TITLE
Add "list" and  "ssh" actions

### DIFF
--- a/src/aiohabit/actions/list.py
+++ b/src/aiohabit/actions/list.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""List action module."""
+
+
+class List:
+    """List action.
+
+    List hosts from DB.
+    """
+
+    def init(self, db_driver):
+        """Initialize the List action."""
+        self._db_driver = db_driver
+
+    def list(self):
+        """Execute the List action."""
+        hosts = self._db_driver.hosts.values()
+
+        for host in hosts:
+            print(host)

--- a/src/aiohabit/actions/ssh.py
+++ b/src/aiohabit/actions/ssh.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SSH action module."""
+
+import os
+import subprocess
+
+from aiohabit.errors import ApplicationError
+from aiohabit.host import STATUS_ACTIVE
+from aiohabit.utils import (
+    get_host_from_metadata,
+    get_username,
+    get_password,
+    get_ssh_key,
+)
+
+
+class SSH:
+    """SSH action.
+
+    SSH all still active provisioned host. Save the state to DB.
+    """
+
+    def init(self, config, metadata, db_driver):
+        """Initialize the SSH action."""
+        self._config = config
+        self._metadata = metadata
+        self._db = db_driver
+
+    def pick_host_interactively(self, hosts):
+        """Print list of host and let user to choose one."""
+        # With only 1 host available, we can pick it and save time
+        if len(hosts) == 1:
+            return hosts[0].name
+
+        for idx, host in enumerate(hosts):
+            print(f"{idx}: {host}")
+
+        while True:
+            try:
+                host_idx = int(input("Enter a number of host to ssh into: "))
+            except ValueError:
+                print("Entered value is not a number.")
+                continue
+            if host_idx < 0 or host_idx >= len(hosts):
+                print("Entered value is not a number of any host.")
+                continue
+            break
+
+        return hosts[host_idx].name
+
+    def find_host(self, hostname):
+        """Find active host based on hostname or interactively."""
+        hosts = self._db.hosts
+        active_hosts = [h for h in hosts.values() if h.status == STATUS_ACTIVE]
+
+        if not hosts:
+            raise ApplicationError("No hosts provisioned.")
+
+        if not active_hosts:
+            raise ApplicationError("No active host available.")
+
+        if not hostname:
+            hostname = self.pick_host_interactively(active_hosts)
+
+        host = hosts.get(hostname)
+        if not host:
+            raise ApplicationError("Specified host does not exist.")
+
+        if host.status != STATUS_ACTIVE:
+            raise ApplicationError("Selected host is not active.")
+
+        return host
+
+    def ssh_to_host(self, host):
+        """SSH to the selected host."""
+        my_env = os.environ.copy()
+
+        run_args = {
+            "env": my_env,
+            "shell": True,
+        }
+
+        cmd = ["ssh"]
+        cmd.extend(["-o", "'StrictHostKeyChecking=no'"])
+        cmd.extend(["-o", "'UserKnownHostsFile=/dev/null'"])
+
+        meta_host, domain = get_host_from_metadata(self._metadata, host.name)
+        username = get_username(host, meta_host, self._config)
+        password = get_password(host, meta_host, self._config)
+        ssh_key = get_ssh_key(host, meta_host, self._config)
+
+        if username:
+            cmd.extend(["-l", username])
+        if ssh_key:
+            cmd.extend(["-i", ssh_key])
+        psw_input = None
+        if password and not ssh_key:
+            cmd.extend("-o", "'PasswordAuthentication'")
+            psw_input = f"{password}\n"
+
+        cmd.append(host.ip)  # Destination
+
+        cmd = " ".join(cmd)
+
+        print(cmd)
+        process = subprocess.Popen(cmd, **run_args)
+        process.communicate(input=psw_input)
+        return process.returncode
+
+    def ssh(self, hostname):
+        """Execute the SSH action."""
+        host = self.find_host(hostname)
+        self.ssh_to_host(host)

--- a/src/aiohabit/errors.py
+++ b/src/aiohabit/errors.py
@@ -21,6 +21,12 @@ class ConfigError(Exception):
     pass
 
 
+class ApplicationError(Exception):
+    """General application error."""
+
+    pass
+
+
 class MetadataError(Exception):
     """Error in job metadata."""
 

--- a/src/aiohabit/host.py
+++ b/src/aiohabit/host.py
@@ -86,7 +86,10 @@ class Host:
         """Return string representation of host."""
         net_str = " ".join(self._ips)
 
-        out = f"{self._id} {self._name} {net_str} {self._username} " f"{self._password}"
+        out = (
+            f"{self._status} {self._id} {self._name} {net_str} {self._username} "
+            f"{self._password}"
+        )
 
         if self._error:
             o = [out, "Error:", object2json(self._error)]

--- a/src/aiohabit/host.py
+++ b/src/aiohabit/host.py
@@ -131,6 +131,12 @@ class Host:
         return self._ips
 
     @property
+    def ip(self):
+        """Get first host IP address."""
+        if self._ips:
+            return self._ips[0]
+
+    @property
     def status(self):
         """Get host status."""
         return self._status

--- a/src/aiohabit/outputs/ansible_inventory.py
+++ b/src/aiohabit/outputs/ansible_inventory.py
@@ -83,7 +83,7 @@ class AnsibleInventoryOutput:
         meta_host, meta_domain = get_host_from_metadata(self._metadata, name)
         db_host = self._db.hosts[name]
 
-        ip = db_host.ips[0]
+        ip = db_host.ip
         ansible_host = resolve_hostname(ip) or ip
 
         python = (

--- a/src/aiohabit/outputs/pytest_multihost.py
+++ b/src/aiohabit/outputs/pytest_multihost.py
@@ -88,7 +88,7 @@ class PytestMultihostOutput:
                 if password:
                     host["password"] = password
 
-                ip = provisioned_host.ips[0]
+                ip = provisioned_host.ip
                 dns_record = resolve_hostname(ip)
                 host["ip"] = ip
                 host["external_hostname"] = dns_record

--- a/src/aiohabit/outputs/utils.py
+++ b/src/aiohabit/outputs/utils.py
@@ -24,17 +24,3 @@ def resolve_hostname(ip):
         return socket.gethostbyaddr(ip)[0]
     except socket_error:
         return None
-
-
-def is_windows_host(meta_host):
-    """
-    Return if host is Windows host based on host metadata info.
-
-    Host is windows host if:
-    * os starts with 'win' or
-    * os_type is 'windows'
-    """
-    return (
-        meta_host.get("os", "").startswith("win")
-        or meta_host.get("os_type", "") == "windows"
-    )

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -25,6 +25,7 @@ from aiohabit.config import ProvisioningConfig
 from aiohabit.actions.destroy import Destroy
 from aiohabit.actions.up import Up
 from aiohabit.actions.output import Output
+from aiohabit.actions.list import List
 from aiohabit.providers import providers
 from aiohabit.providers.openstack import OpenStackProvider, PROVISIONER_KEY as OPENSTACK
 from aiohabit.providers.aws import AWSProvider, PROVISIONER_KEY as AWS
@@ -128,6 +129,16 @@ async def output(ctx, metadata):
     output_action = Output()
     await output_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
     await output_action.generate_outputs()
+
+
+@aiohabitcli.command()
+@click.pass_context
+@async_run
+async def list(ctx):
+    """List host tracked by."""
+    list_action = List()
+    list_action.init(ctx.obj[DB])
+    list_action.list()
 
 
 def exception_handler(func):

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -26,6 +26,7 @@ from aiohabit.actions.destroy import Destroy
 from aiohabit.actions.up import Up
 from aiohabit.actions.output import Output
 from aiohabit.actions.list import List
+from aiohabit.actions.ssh import SSH
 from aiohabit.providers import providers
 from aiohabit.providers.openstack import OpenStackProvider, PROVISIONER_KEY as OPENSTACK
 from aiohabit.providers.aws import AWSProvider, PROVISIONER_KEY as AWS
@@ -139,6 +140,20 @@ async def list(ctx):
     list_action = List()
     list_action.init(ctx.obj[DB])
     list_action.list()
+
+
+@aiohabitcli.command()
+@click.pass_context
+@click.argument("metadata", type=click.Path(exists=True))
+@click.argument("hostname", required=False)
+@async_run
+async def ssh(ctx, metadata, hostname):
+    """SSH to host."""
+    ctx.obj[METADATA] = init_metadata(metadata)
+
+    ssh_action = SSH()
+    ssh_action.init(ctx.obj[CONFIG], ctx.obj[METADATA], ctx.obj[DB])
+    ssh_action.ssh(hostname)
 
 
 def exception_handler(func):


### PR DESCRIPTION
This is a follow up after(based on) https://github.com/pvoborni/aiohabit/pull/7 

## List action
To quickly show content of DB in human readable form

## SSH action
To make it very easy to SSH into a host based on value in various  configuration objects.
    
It is usually very time-consuming to "cat" e.g. inventory, copy the real hostname/IP, write all the SSH options including determining if it should use SSH key and what is its location.
    
The interactive mode even saves time with writing the fake hostname.

The bad UX of these actions is a need to provide metadata/config paths. In some other PR, we should figure out some reasonable default so that ppl can simply execute: `aiohabit list` and `aiohabit ssh`
