### PR TITLE
Static provider

### DIFF
--- a/src/aiohabit/outputs/ansible_inventory.py
+++ b/src/aiohabit/outputs/ansible_inventory.py
@@ -87,7 +87,8 @@ class AnsibleInventoryOutput:
         ansible_host = resolve_hostname(ip) or ip
 
         python = (
-            self._config["python"][meta_host["os"]] or self._config["python"]["default"]
+            self._config["python"].get(meta_host["os"])
+            or self._config["python"]["default"]
         )
 
         ansible_user = get_username(db_host, meta_host, self._config)

--- a/src/aiohabit/providers/static.py
+++ b/src/aiohabit/providers/static.py
@@ -1,0 +1,73 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static provider."""
+
+from aiohabit.providers.provider import Provider
+from aiohabit.host import (
+    Host,
+    STATUS_ACTIVE,
+)
+from aiohabit.errors import ValidationError
+
+PROVISIONER_KEY = "static"
+
+
+class StaticProvider(Provider):
+    """
+    Static Provider.
+
+    Doesn't provision anything. Only simulates provisioning so that
+    we can track the server in output modules and other actions.
+    """
+
+    def __init__(self):
+        """Object initialization."""
+        self._name = PROVISIONER_KEY
+
+    async def validate_hosts(self, reqs):
+        """Validate that host requirements are well specified."""
+        for req in reqs:
+            if "name" not in req:
+                raise ValidationError("Name not found")
+            if "ip" not in req:
+                raise ValidationError("IP address (ip) not found")
+        return True
+
+    async def can_provision(self, hosts):
+        """Behave as that we can."""
+        return True
+
+    async def provision_hosts(self, reqs):
+        """Fake provision - behave as if it was provisioned."""
+        await self.validate_hosts(reqs)
+        hosts = [self.to_host(req) for req in reqs]
+        return hosts
+
+    async def delete_host(self, host):
+        """Fake delete - pass but don't do anything."""
+        return True
+
+    def to_host(self, req):
+        """Transform req into Host object."""
+        host = Host(
+            self,
+            req.get("name"),
+            req.get("name"),
+            [req.get("ip")],
+            STATUS_ACTIVE,
+            req,
+            error_obj={},
+        )
+        return host

--- a/src/aiohabit/run.py
+++ b/src/aiohabit/run.py
@@ -30,6 +30,7 @@ from aiohabit.actions.ssh import SSH
 from aiohabit.providers import providers
 from aiohabit.providers.openstack import OpenStackProvider, PROVISIONER_KEY as OPENSTACK
 from aiohabit.providers.aws import AWSProvider, PROVISIONER_KEY as AWS
+from aiohabit.providers.static import StaticProvider, PROVISIONER_KEY as STATIC
 from aiohabit.errors import ConfigError, MetadataError, ValidationError, ProviderError
 
 
@@ -48,6 +49,7 @@ def init_providers():
     """Register all providers usable in this session."""
     providers.register(OPENSTACK, OpenStackProvider)
     providers.register(AWS, AWSProvider)
+    providers.register(STATIC, StaticProvider)
 
 
 def init_db(path):

--- a/src/aiohabit/transformers/__init__.py
+++ b/src/aiohabit/transformers/__init__.py
@@ -24,6 +24,7 @@ from aiohabit.transformers.openstack import (
     CONFIG_KEY as OPENSTACK_KEY,
 )
 from aiohabit.transformers.aws import AWSTransformer, CONFIG_KEY as AWS_KEY
+from aiohabit.transformers.static import StaticTransformer, CONFIG_KEY as STATIC_KEY
 
 
 class Registry:
@@ -61,3 +62,4 @@ class Registry:
 transformers = Registry()
 transformers.register(OPENSTACK_KEY, OpenStackTransformer)
 transformers.register(AWS_KEY, AWSTransformer)
+transformers.register(STATIC_KEY, StaticTransformer)

--- a/src/aiohabit/transformers/static.py
+++ b/src/aiohabit/transformers/static.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static transformer module."""
+
+from aiohabit.transformers.transformer import Transformer
+from copy import deepcopy
+
+CONFIG_KEY = "static"
+
+
+class StaticTransformer(Transformer):
+    """
+    Static transformer.
+
+    Does almost no operation as there is nothing to provision.
+    """
+
+    _config_key = CONFIG_KEY
+    _required_config_attrs = []
+    _required_host_attrs = ["name", "os", "group", "ip"]
+
+    async def init_provider(self):
+        """Initialize associate provider."""
+        pass
+
+    def create_host_requirement(self, host):
+        """Create single input for Static provisioner."""
+        return deepcopy(host)
+
+    def create_host_requirements(self):
+        """Create inputs for all host for Static provisioner."""
+        reqs = [self.create_host_requirement(host) for host in self.hosts]
+        return reqs


### PR DESCRIPTION
Static provider
    
    Static provider serves for mixing already provisioned hosts (pets)
    with dynamically provisioned hosts. Alternatively all hosts can
    be static. This can be useful for generating the outputs and using
    other features.
    
    Almost all operations are fake given that the hosts exist and cannot
    be deleted by static provider. The most important parts is to provide
    a name and ip.
    
    Signed-off-by: Petr Vobornik <pvoborni@redhat.com>

ansible-inventory: fix bug when python interpreter not defined for os
    
    E.g. so that the default python interpreter will be used.
    
    Signed-off-by: Petr Vobornik <pvoborni@redhat.com>